### PR TITLE
improved filter comparison during from_config

### DIFF
--- a/docs/coverage/coverage.svg
+++ b/docs/coverage/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">73%</text>
+        <text x="80" y="14">73%</text>
     </g>
 </svg>

--- a/docs/coverage/coverage.txt
+++ b/docs/coverage/coverage.txt
@@ -1,11 +1,11 @@
 Name                                                                Stmts   Miss  Cover   Missing
 -------------------------------------------------------------------------------------------------
-maze_dataset\__init__.py                                                5      0   100%
+maze_dataset\__init__.py                                                6      0   100%
 maze_dataset\constants.py                                               9      0   100%
 maze_dataset\dataset\__init__.py                                        3      0   100%
 maze_dataset\dataset\collected_dataset.py                              96      5    95%   43, 55, 59, 164-168
 maze_dataset\dataset\configs.py                                         3      3     0%   1-4
-maze_dataset\dataset\dataset.py                                       178     55    69%   26-29, 56, 59, 67-68, 80, 84, 94, 98-103, 109, 115, 225, 233-237, 240-249, 253, 260, 264-267, 271, 275, 293, 296, 300, 305, 309, 317, 349-363, 395
+maze_dataset\dataset\dataset.py                                       192    118    39%   27-35, 45, 50, 59-74, 85-86, 89-90, 93-95, 99-121, 127, 198, 223, 230-253, 257-263, 266-270, 274, 279, 284, 291-297, 300-301, 305-306, 309-318, 324, 332-334, 338-342, 347-364, 372, 383-407, 432-434, 438-441, 460-470
 maze_dataset\dataset\maze_dataset.py                                  219     49    78%   58, 65-72, 154, 157, 163-165, 208-212, 232, 252-258, 266-268, 463-466, 487, 512-517, 536-540, 547-590
 maze_dataset\generation\__init__.py                                     2      0   100%
 maze_dataset\generation\generators.py                                 120      0   100%
@@ -15,8 +15,8 @@ maze_dataset\plotting\__init__.py                                       3      3
 maze_dataset\plotting\plot_dataset.py                                  22     22     0%   1-29
 maze_dataset\plotting\plot_maze.py                                    167    167     0%   1-445
 maze_dataset\tokenization\__init__.py                                   0      0   100%
-maze_dataset\tokenization\token_utils.py                               49      4    92%   32, 43, 92-93
-maze_dataset\utils.py                                                  16      0   100%
+maze_dataset\tokenization\token_utils.py                               53      7    87%   32, 43, 92-93, 114-116
+maze_dataset\utils.py                                                  19      1    95%   69
 setup.py                                                                3      3     0%   3-6
 tests\unit\maze_dataset\dataset\test_collected_dataset.py              45      0   100%
 tests\unit\maze_dataset\generation\test_bool_array_from_string.py      15      0   100%
@@ -28,4 +28,4 @@ tests\unit\maze_dataset\generation\test_maze_dataset.py               100      0
 tests\unit\maze_dataset\generation\test_solved_maze.py                 13      7    46%   12-21
 tests\unit\maze_dataset\utils\test_token_utils.py                      52      0   100%
 -------------------------------------------------------------------------------------------------
-TOTAL                                                                1662    390    77%
+TOTAL                                                                1684    457    73%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "maze-dataset"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Michael Ivanitskiy <miv@knc.ai>", "Dan Valentine <danvalentine256@gmail.com>", "Rusheb Shah <rusheb.shah@gmail.com>", "Lucia Quirke <luciaq@canva.com>", "Can Rager <can.rager@posteo.de>", "Alex Spies <alexfspies@gmail.com>", "Chris Mathwin <cwmathwin@gmail.com>", "Tilman Rauker <traeuker@googlemail.com>", "Guillaume Corlouer <guillaume.corlouer@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- now a custom function performs checks more carefully, called at the end of _apply_filters_from_config
- a custom FilterInfoMismatchError will be thrown instead
 of generic AssertionError, with better info on what went wrong
- we were getting a type error with custom filters being passed because empty `list()` is not equal to empty `tuple()`, this should fix that

# TODO:
- [ ] use a SerializableDataclass for specifying applied filters, perform checks there?